### PR TITLE
Update physlite Dockerfiles

### DIFF
--- a/daskhub/docker/daskgateway-physlite/0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch
+++ b/daskhub/docker/daskgateway-physlite/0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch
@@ -1,0 +1,29 @@
+From 060e4b124a8b1781504b8f894aa3c210cee513c1 Mon Sep 17 00:00:00 2001
+From: Angus Hollands <goosey15@gmail.com>
+Date: Tue, 15 Jun 2021 11:16:27 +0100
+Subject: [PATCH] Bugfix: check for `file`-like objects in `from_parquet`
+
+---
+ src/awkward/operations/convert.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/awkward/operations/convert.py b/src/awkward/operations/convert.py
+index 751ad727..dc20615e 100644
+--- a/src/awkward/operations/convert.py
++++ b/src/awkward/operations/convert.py
+@@ -3613,7 +3613,11 @@ def from_parquet(
+             relative_to = source
+             source = sorted(glob.glob(source + "/**/*.parquet", recursive=True))
+ 
+-    if not isinstance(source, str) and isinstance(source, Iterable):
++    if (
++        not isinstance(source, str)
++        and isinstance(source, Iterable)
++        and not hasattr(source, "read")
++    ):
+         source = [_regularize_path(x) for x in source]
+         if relative_to is None:
+             relative_to = os.path.commonpath(source)
+-- 
+2.32.0
+

--- a/daskhub/docker/daskgateway-physlite/Dockerfile
+++ b/daskhub/docker/daskgateway-physlite/Dockerfile
@@ -3,5 +3,10 @@ USER root
 RUN apt-get update --yes && apt-get install --yes git openssh-client
 USER 1000:1000
 RUN pip install --no-cache-dir numpy h5py numba uproot awkward pyarrow coffea aiohttp
-RUN pip install --no-cache-dir git+https://gitlab.cern.ch/nihartma/physlite-experiments@e11521d5d67248b5f463087b7afde5cae78b02b8
+RUN pip install --no-cache-dir git+https://gitlab.cern.ch/nihartma/physlite-experiments@f5d092ffdfc03d35a6318f9cc9091d9de3b9fd45
 RUN pip install --no-cache-dir rucio-clients
+RUN cp /opt/conda/etc/rucio.cfg.atlas.client.template /opt/conda/etc/rucio.cfg
+COPY 0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch /opt/conda/lib/python3.8/site-packages/awkward/
+WORKDIR /opt/conda/lib/python3.8/site-packages/awkward
+RUN patch -p3 < 0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch
+WORKDIR /home/dask

--- a/daskhub/docker/jupyter-physlite/0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch
+++ b/daskhub/docker/jupyter-physlite/0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch
@@ -1,0 +1,29 @@
+From 060e4b124a8b1781504b8f894aa3c210cee513c1 Mon Sep 17 00:00:00 2001
+From: Angus Hollands <goosey15@gmail.com>
+Date: Tue, 15 Jun 2021 11:16:27 +0100
+Subject: [PATCH] Bugfix: check for `file`-like objects in `from_parquet`
+
+---
+ src/awkward/operations/convert.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/awkward/operations/convert.py b/src/awkward/operations/convert.py
+index 751ad727..dc20615e 100644
+--- a/src/awkward/operations/convert.py
++++ b/src/awkward/operations/convert.py
+@@ -3613,7 +3613,11 @@ def from_parquet(
+             relative_to = source
+             source = sorted(glob.glob(source + "/**/*.parquet", recursive=True))
+ 
+-    if not isinstance(source, str) and isinstance(source, Iterable):
++    if (
++        not isinstance(source, str)
++        and isinstance(source, Iterable)
++        and not hasattr(source, "read")
++    ):
+         source = [_regularize_path(x) for x in source]
+         if relative_to is None:
+             relative_to = os.path.commonpath(source)
+-- 
+2.32.0
+

--- a/daskhub/docker/jupyter-physlite/Dockerfile
+++ b/daskhub/docker/jupyter-physlite/Dockerfile
@@ -7,4 +7,8 @@ ENV PATH=/srv/conda/envs/notebook/bin:$PATH
 RUN pip install --no-cache-dir rucio-clients
 RUN cp /srv/conda/envs/notebook/etc/rucio.cfg.atlas.client.template /srv/conda/envs/notebook/etc/rucio.cfg
 RUN pip install --no-cache-dir numpy h5py numba uproot awkward pyarrow coffea aiohttp
-RUN pip install --no-cache-dir git+https://gitlab.cern.ch/nihartma/physlite-experiments@e11521d5d67248b5f463087b7afde5cae78b02b8
+RUN pip install --no-cache-dir git+https://gitlab.cern.ch/nihartma/physlite-experiments@f5d092ffdfc03d35a6318f9cc9091d9de3b9fd45
+COPY 0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch /srv/conda/envs/notebook/lib/python3.8/site-packages/awkward/
+WORKDIR /srv/conda/envs/notebook/lib/python3.8/site-packages/awkward
+RUN patch -p3 < 0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch
+WORKDIR /home/jovyan


### PR DESCRIPTION
@fbarreir can you update the physlite images once again? I made the following modifications:

* add bugfix patch for scikit-hep/awkward-1.0#921
* update physlite-experiments code
* copy rucio ATLAS template for daskgateway image

The bugfix for awkward (and the update to physlite-experiments) is needed when i want run on parquet files via http.