### PR TITLE
add google bigquery packages and update physlite code

### DIFF
--- a/daskhub/docker/daskgateway-physlite/Dockerfile
+++ b/daskhub/docker/daskgateway-physlite/Dockerfile
@@ -3,8 +3,10 @@ USER root
 RUN apt-get update --yes && apt-get install --yes git openssh-client
 USER 1000:1000
 RUN pip install --no-cache-dir numpy h5py numba uproot awkward pyarrow coffea aiohttp
-RUN pip install --no-cache-dir git+https://gitlab.cern.ch/nihartma/physlite-experiments@f5d092ffdfc03d35a6318f9cc9091d9de3b9fd45
 RUN pip install --no-cache-dir rucio-clients
+RUN conda install "pyyaml>=5.2" # does not work with pip
+RUN pip install --no-cache-dir google.cloud.bigquery_storage google-cloud-bigquery
+RUN pip install --no-cache-dir git+https://gitlab.cern.ch/nihartma/physlite-experiments@723fa0a3f615514843b64e2e6ebcf85e6b44cfc4
 RUN cp /opt/conda/etc/rucio.cfg.atlas.client.template /opt/conda/etc/rucio.cfg
 COPY 0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch /opt/conda/lib/python3.8/site-packages/awkward/
 WORKDIR /opt/conda/lib/python3.8/site-packages/awkward

--- a/daskhub/docker/jupyter-physlite/Dockerfile
+++ b/daskhub/docker/jupyter-physlite/Dockerfile
@@ -7,7 +7,8 @@ ENV PATH=/srv/conda/envs/notebook/bin:$PATH
 RUN pip install --no-cache-dir rucio-clients
 RUN cp /srv/conda/envs/notebook/etc/rucio.cfg.atlas.client.template /srv/conda/envs/notebook/etc/rucio.cfg
 RUN pip install --no-cache-dir numpy h5py numba uproot awkward pyarrow coffea aiohttp
-RUN pip install --no-cache-dir git+https://gitlab.cern.ch/nihartma/physlite-experiments@f5d092ffdfc03d35a6318f9cc9091d9de3b9fd45
+RUN pip install --no-cache-dir google.cloud.bigquery_storage google-cloud-bigquery
+RUN pip install --no-cache-dir git+https://gitlab.cern.ch/nihartma/physlite-experiments@723fa0a3f615514843b64e2e6ebcf85e6b44cfc4
 COPY 0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch /srv/conda/envs/notebook/lib/python3.8/site-packages/awkward/
 WORKDIR /srv/conda/envs/notebook/lib/python3.8/site-packages/awkward
 RUN patch -p3 < 0001-Bugfix-check-for-file-like-objects-in-from_parquet.patch


### PR DESCRIPTION
For the `dask-gateway` image there was an error for installing the `pyyaml` dependency for the google bigquery packages:

```
ERROR: Cannot uninstall 'PyYAML'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```

I circumvented this now by upgrading pyyaml before with conda