### PR TITLE
update pangeo/base-notebook

### DIFF
--- a/daskhub/docker/jupyter-physlite/Dockerfile
+++ b/daskhub/docker/jupyter-physlite/Dockerfile
@@ -1,5 +1,5 @@
 # Documentation: https://zero-to-jupyterhub.readthedocs.io/en/latest/jupyterhub/customizing/user-environment.html
-FROM pangeo/base-notebook:2021.07.06
+FROM pangeo/base-notebook:2022.03.08
 USER root
 RUN apt-get update --yes && apt-get install --yes git openssh-client
 USER jovyan


### PR DESCRIPTION
@fbarreir can you update the physlite image again? I'd like to try a new version of the base image which contains new versions of the dask packages. There is a new option to specify environment variables to the workers which also includes by default something to make memory trimming more agressive as described here

http://distributed.dask.org/en/latest/worker-memory.html?highlight=distributed.nanny.environ#automatically-trim-memory

It seems that some of the memory issues i see in my tests might be mitigated by this. Not sure if it will be propagated to dask gateway, but i would like to give it a try.