### PR TITLE
Dockerfile for dask-awkward compatible packages

### DIFF
--- a/daskhub/docker/jupyter-physlite-dask-awkward/Dockerfile
+++ b/daskhub/docker/jupyter-physlite-dask-awkward/Dockerfile
@@ -1,0 +1,11 @@
+# Documentation: https://zero-to-jupyterhub.readthedocs.io/en/latest/jupyterhub/customizing/user-environment.html
+FROM pangeo/base-notebook:2023.07.05
+USER root
+RUN apt-get update --yes && apt-get install --yes git openssh-client
+USER jovyan
+ENV PATH=/srv/conda/envs/notebook/bin:$PATH
+RUN pip install --no-cache-dir rucio-clients
+RUN cp /srv/conda/envs/notebook/etc/rucio.cfg.atlas.client.template /srv/conda/envs/notebook/etc/rucio.cfg
+RUN pip install --no-cache-dir numpy h5py numba pyarrow aiohttp
+RUN pip install --no-cache-dir google.cloud.bigquery_storage google-cloud-bigquery
+RUN pip install --no-cache-dir 'uproot>=5' 'awkward>=2' 'coffea==v2023.7.0.rc0' vector particle 'hist[plot]'


### PR DESCRIPTION
@fbarreir - i'd like to perform some tests using dask-awkward which requires newer versions of uproot, awkward and coffea. So far i didn't include any custom code since my old stuff is largely incompatible with this. Therefore i would also like to keep the old image (jupyter-physlite) in case i want to rerun and compare to the old stuff.